### PR TITLE
Fixed spelling error in Makefile.STM32FX

### DIFF
--- a/Makefile.STM32FX
+++ b/Makefile.STM32FX
@@ -15,7 +15,7 @@ OBJDIR_F4=obj_f4
 BINELF_F1=dvm-firmware-hs_f1.elf
 BINHEX_F1=dvm-firmware-hs_f1.hex
 BINBIN_F1=dvm-firmware-hs_f1.bin
-BINELF_F4=dvm-firwmare-hs_f4.elf
+BINELF_F4=dvm-firmware-hs_f4.elf
 BINHEX_F4=dvm-firmware-hs_f4.hex
 BINBIN_F4=dvm-firmware-hs_f4.bin
 


### PR DESCRIPTION
wrong name for output file "dvm-firmware-hs_f4.elf", minor bug, no impact on compilation and use.
Please let me know if this file name is deliberately adopted.www